### PR TITLE
action to push the changes in PR

### DIFF
--- a/pr-git-push/Dockerfile
+++ b/pr-git-push/Dockerfile
@@ -1,0 +1,9 @@
+FROM eu.gcr.io/voi-stage/builder:7.2
+
+RUN apk update && \
+    apk add --no-cache --update jq
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/pr-git-push/README.md
+++ b/pr-git-push/README.md
@@ -1,0 +1,44 @@
+### GitHub push action
+
+Pushes any changes in pull request made to a GitHub using the GITHUB_TOKEN. Effectively it's doing the following:
+
+> ⚠️ **Warning**: It is working only as a part of the pull request's job
+ 
+```
+git diff --quiet || (
+  git checkout "$HEAD_BRANCH" && \
+    git add . && \
+    git commit -m "$1" && \
+    git push origin "$HEAD_BRANCH"
+)
+```
+
+### Usage
+
+```
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  go-generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout sources
+        uses: actions/checkout@master
+
+      - name: push changes
+        uses: ./.github/actions/git-push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          commit-message: "Commit message"
+```
+
+### Arguments
+
+| Key | Description | Default |
+|---:|---|---|
+| `commit-message` | A commit message to use | default message |
+| `commit-user-name` | User name | voi-bender |
+| `commit-user-email` | User email | tech@voiapp.io |

--- a/pr-git-push/README.md
+++ b/pr-git-push/README.md
@@ -35,6 +35,15 @@ jobs:
           commit-message: "Commit message"
 ```
 
+### Environment variables
+| Key | Description |
+|---:|---|
+| `GCLOUD_AUTH` | Service account |
+| `GITHUB_TOKEN` | Current GitHub token used by a job |
+
+> **Q**: Why we're doing gcloud auth here?
+> A: Builder image contains a SSH key, but it's encrypted with gcloud KMS. Haven't found how to do it right using the GITHUB_TOKEN. 
+
 ### Arguments
 
 | Key | Description | Default |

--- a/pr-git-push/action.yml
+++ b/pr-git-push/action.yml
@@ -1,0 +1,26 @@
+name: 'Git push in PR'
+description: 'Git push the changes in pull request'
+author: 'VOI'
+inputs:
+  commit-message:
+    description: 'Commit message'
+    default: 'default message'
+  commit-user-name:
+    description: 'User name to use with a commit'
+    default: 'voi-bender'
+  commit-user-email:
+    description: 'User email to use with a commit'
+    default: 'tech@voiapp.io'
+
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  env:
+    COMMIT_USER_NAME: ${{ inputs.commit-user-name }}
+    COMMIT_USER_EMAIL: ${{ inputs.commit-user-email }}
+  args:
+    - ${{ inputs.commit-message }}
+
+branding:
+  icon: 'award'
+  color: 'green'

--- a/pr-git-push/entrypoint.sh
+++ b/pr-git-push/entrypoint.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -e
+
+/setup-ci.sh
+git config --global user.name "$COMMIT_USER_NAME"
+git config --global user.email "$COMMIT_USER_EMAIL"
+
+# shellcheck disable=SC2002
+# shellcheck disable=SC2046
+DIFF_URL=$(cat "$GITHUB_EVENT_PATH" | jq -r ".pull_request.diff_url")
+REPO_FULLNAME=$(cat "$GITHUB_EVENT_PATH" | jq -r ".pull_request.head.repo.full_name")
+PR_NUMBER=$(basename "$DIFF_URL" | sed -e "s/.diff//")
+
+echo "PR_NUMBER: $PR_NUMBER"
+echo "GITHUB_TOKEN: $GITHUB_TOKEN"
+echo "REPO_FULLNAME: $REPO_FULLNAME"
+
+URI=https://api.github.com
+API_HEADER="Accept: application/vnd.github.v3+json"
+AUTH_HEADER="Authorization: token $GITHUB_TOKEN"
+
+pr_resp=$(curl -X GET -s -H "${AUTH_HEADER}" -H "${API_HEADER}" "${URI}/repos/$REPO_FULLNAME/pulls/$PR_NUMBER")
+BASE_BRANCH=$(echo "$pr_resp" | jq -r .base.ref)
+
+# shellcheck disable=SC2039
+if [[ -z "$BASE_BRANCH" ]]; then
+  echo "Cannot get base branch information for PR #$PR_NUMBER!"
+  echo "API response: $pr_resp"
+  exit 1
+fi
+
+HEAD_BRANCH=$(echo "$pr_resp" | jq -r .head.ref)
+
+echo "HEAD branch of PR: ${HEAD_BRANCH}"
+echo "Base branch for PR #$PR_NUMBER is $BASE_BRANCH"
+
+git diff --quiet || (
+  git checkout "$HEAD_BRANCH" && \
+    git add . && \
+    git commit -m "$1" && \
+    git push origin "$HEAD_BRANCH"
+)

--- a/pr-git-push/entrypoint.sh
+++ b/pr-git-push/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+echo "$GCLOUD_AUTH" | python -m base64 -d > "$HOME"/gcloud.json
+sh -c "gcloud auth activate-service-account --key-file=$HOME/gcloud.json"
+
 /setup-ci.sh
 git config --global user.name "$COMMIT_USER_NAME"
 git config --global user.email "$COMMIT_USER_EMAIL"


### PR DESCRIPTION
### GitHub push action

Pushes any changes in pull request made to a GitHub using the GITHUB_TOKEN. Effectively it's doing the following:

> ⚠️ **Warning**: It is working only as a part of the pull request's job
 
```
git diff --quiet || (
  git checkout "$HEAD_BRANCH" && \
    git add . && \
    git commit -m "$1" && \
    git push origin "$HEAD_BRANCH"
)
```

### Usage

```
on:
  pull_request:
    types: [opened]

jobs:
  go-generate:
    runs-on: ubuntu-latest
    steps:
      - name: checkout sources
        uses: actions/checkout@master

      - name: push changes
        uses: ./.github/actions/git-push
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        with:
          commit-message: "Commit message"
```

### Environment variables
| Key | Description |
|---:|---|
| `GCLOUD_AUTH` | Service account |
| `GITHUB_TOKEN` | Current GitHub token used by a job |

> **Q**: Why we're doing gcloud auth here?
> A: Builder image contains a SSH key, but it's encrypted with gcloud KMS. Haven't found how to do it right using the GITHUB_TOKEN. 

### Arguments

| Key | Description | Default |
|---:|---|---|
| `commit-message` | A commit message to use | default message |
| `commit-user-name` | User name | voi-bender |
| `commit-user-email` | User email | tech@voiapp.io |
