### PR TITLE
Use SHORT_SHA according to command git rev-parse --short

### DIFF
--- a/argo-cd-release-production/action.yml
+++ b/argo-cd-release-production/action.yml
@@ -21,7 +21,7 @@ runs:
       shell: bash
       run: |
         TAG=$(basename ${GITHUB_REF})
-        SHA=$(echo $GITHUB_SHA | cut -c 1-7)
+        SHA=$(echo $GITHUB_SHA | cut -c 1-8)
         VALUES_FILE="${{ github.event.repository.name }}/values/prod.yaml"
         VERSION="${TAG}-${SHA}"
 

--- a/argo-cd-release-staging/action.yml
+++ b/argo-cd-release-staging/action.yml
@@ -21,7 +21,7 @@ runs:
           TAG=PR-${{ github.event.pull_request.number }}
         fi
 
-        SHA=$(echo $GITHUB_SHA | cut -c 1-7)
+        SHA=$(echo $GITHUB_SHA | cut -c 1-8)
         VALUES_FILE="${{ github.event.repository.name }}/values/stage.yaml"
         VERSION="${TAG}-${SHA}"
 


### PR DESCRIPTION
According to boilerplate
https://github.com/voiapp/bootstrap/blob/master/Makefile, the images
follow the standard of $(TAG_NAME)-$(SHORT_SHA), which SHORT_SHA is the
output of git rev-parse --shortl, a command that always return 8
characters from SHA. Let's keep the same standard while creating the
yaml