### PR TITLE
Escape commit message - FLAT-1031

### DIFF
--- a/argo-cd-release-production/action.yml
+++ b/argo-cd-release-production/action.yml
@@ -46,8 +46,10 @@ runs:
         yq w --inplace ${VALUES_FILE} "version" ${VERSION}
 
         # fully qualify the PR number (e.g. #123) as GitHub UI will incorrectly interpret it as a local PR
+        # we must use toJSON function to avoid breaking echo when quotes are in commit messages
+        ESCAPED_COMMIT_MESSAGE=$(echo ${{ toJSON(github.event.head_commit.message) }})
         URL="https:\/\/github.com\/voiapp\/"${{ github.event.repository.name }}"\/pull\/"
-        MESSAGE=$(echo "${{github.event.head_commit.message}}" | sed 's/\(.*\)#/\1 '"$URL"'/')
+        MESSAGE=$(echo "$ESCAPED_COMMIT_MESSAGE" | sed 's/\(.*\)#/\1 '"$URL"'/')
 
         git commit -am "Set image for deploy using tag ${VERSION}. Commit: ${MESSAGE} by ${{github.event.head_commit.author.name}}"
         git push --set-upstream origin deploy-prod-${{github.sha}}
@@ -58,8 +60,10 @@ runs:
         MANIFEST_REPO_BRANCH: "main"
       run: |
         # fully qualify the PR number (e.g. #123) as GitHub UI will incorrectly interpret it as a local PR
+        # we must use toJSON function to avoid breaking echo when quotes are in commit messages
+        ESCAPED_COMMIT_MESSAGE=$(echo ${{ toJSON(github.event.head_commit.message) }})
         URL="https:\/\/github.com\/voiapp\/"${{ github.event.repository.name }}"\/pull\/"
-        MESSAGE=$(echo "${{github.event.head_commit.message}}" | sed 's/\(.*\)#/\1 '"$URL"'/')
+        MESSAGE=$(echo "$ESCAPED_COMMIT_MESSAGE" | sed 's/\(.*\)#/\1 '"$URL"'/')
 
         gh auth login --with-token <<< ${{ inputs.github-pat }}
         gh pr create -t "Deploy ${{ github.event.repository.name }} to production by ${{github.event.head_commit.author.name}}" \


### PR DESCRIPTION
This was crazy hard to get right! 

Problem:
The root cause was when calling `echo "${{github.event.head_commit.message}}"`. GitHub actions removes the escaping that was present in the JSON objects representing the events. This means any double quotes in the context variables will break any bash command using them. Using sed or similar to perform the replacement isn't possible as we need to first read the context variable using echo before even trying to use sed and friends.

Solution:
`echo ${{ toJSON(github.event.head_commit.message) }}` will take the escaped string raw from the JSON. It is important not to quote the context variable as this will result in double quoting and mess up further string parsing.

I used https://github.com/nektos/act to create the test case to fix this. It turns out `act` has a lot of limitations (no composite support and other structures unsupported)

Run:
`act --eventpath  events.json -v`

events.json:
`{
  "head_commit": {
    "message": "test escaped commits with a quote\"",
    "author": {
      "name": "ronan"
    }
  },
  "repository": {
    "name": "repo"
  },
  "pull_request": {
    "head": {
     "message": "random", 
     "ref": "sample-head-ref"
    },
    "base": {
      "ref": "sample-base-ref"
    }
  }
}`

action.yaml (segment):
`
        # fully qualify the PR number (e.g. #123) as GitHub UI will incorrectly interpret it as a local PR
        ESCAPED_COMMIT_MESSAGE=$(echo ${{ toJSON(github.event.head_commit.message) }})
`

The solution has been tested using single quotes, double quotes and double double quotes.