### PR TITLE
Supporting more environments - FLAT-1116

### DIFF
--- a/argo-cd-release-staging/README.md
+++ b/argo-cd-release-staging/README.md
@@ -11,6 +11,10 @@ It expects a `push` target to be available in a Makefile.
 
 **Required** — Github short SHA
 
+### `environment`
+
+**Optional** — Where to deploy the change
+
 ## Example usage
 
 ```yaml

--- a/argo-cd-release-staging/action.yml
+++ b/argo-cd-release-staging/action.yml
@@ -4,6 +4,10 @@ description: 'Release to staging'
 inputs:
   short-sha:
     description: 'Github short SHA'
+  environment:
+    description: 'Environment to deploy to'
+    required: false
+    default: 'stage'
 
 runs:
   using: "composite"
@@ -18,6 +22,11 @@ runs:
     - name: Update image with yq and push commit
       shell: bash
       run: |
+        # never allow this action to manipulate prod.yaml
+        if [ "${{ inputs.environment }}" == "prod" ]
+        then
+          exit 1
+        fi
         if [ -z "${{ github.event.pull_request.number }}" ]
         then
           TAG=$(basename ${GITHUB_REF})
@@ -32,7 +41,7 @@ runs:
           SHA=${{ inputs.short-sha }}
         fi
 
-        VALUES_FILE="${{ github.event.repository.name }}/values/stage.yaml"
+        VALUES_FILE="${{ github.event.repository.name }}/values/${{ inputs.environment }}.yaml"
         VERSION="${TAG}-${SHA}"
 
         [ -f $VALUES_FILE ] || ( echo "$VALUES_FILE does not exist. Is the service configured to be deployed with Argo CD?"; exit 1 )


### PR DESCRIPTION
- Parameter for environment so builds can be deployed anywhere
- I didn't change the file name from `argo-cd-release-staging/action.yml` as that isn't backwards compatible
- Requires a new workflow "dev.yaml" and "load-yaml" in every repo which isn't optimal
- Tested with repo https://github.com/voiapp/argo-cd-example/pull/87