### PR TITLE
Support multi env commit

### DIFF
--- a/argo-cd-release-staging/action.yml
+++ b/argo-cd-release-staging/action.yml
@@ -42,7 +42,7 @@ runs:
         fi
 
         # modify the values file for each environment
-        ENVIRONMENTS=${{ inputs.environment }}
+        ENVIRONMENTS=$(echo ${{ inputs.environment }} | tr -d "[:blank:]")
         for i in ${ENVIRONMENTS//,/ }
         do
           VALUES_FILE="${{ github.event.repository.name }}/values/$i.yaml"

--- a/argo-cd-release-staging/action.yml
+++ b/argo-cd-release-staging/action.yml
@@ -41,14 +41,19 @@ runs:
           SHA=${{ inputs.short-sha }}
         fi
 
-        VALUES_FILE="${{ github.event.repository.name }}/values/${{ inputs.environment }}.yaml"
-        VERSION="${TAG}-${SHA}"
+        # modify the values file for each environment
+        ENVIRONMENTS=${{ inputs.environment }}
+        for i in ${ENVIRONMENTS//,/ }
+        do
+          VALUES_FILE="${{ github.event.repository.name }}/values/$i.yaml"
+          VERSION="${TAG}-${SHA}"
 
-        [ -f $VALUES_FILE ] || ( echo "$VALUES_FILE does not exist. Is the service configured to be deployed with Argo CD?"; exit 1 )
+          [ -f $VALUES_FILE ] || ( echo "$VALUES_FILE does not exist. Is the service configured to be deployed with Argo CD?"; exit 1 )
 
-        IMAGE=$(yq r ${VALUES_FILE} "image" | sed "s/:.*$//")":${VERSION}"
-        yq w --inplace ${VALUES_FILE} "image" ${IMAGE}
-        yq w --inplace ${VALUES_FILE} "version" ${VERSION}
+          IMAGE=$(yq r ${VALUES_FILE} "image" | sed "s/:.*$//")":${VERSION}"
+          yq w --inplace ${VALUES_FILE} "image" ${IMAGE}
+          yq w --inplace ${VALUES_FILE} "version" ${VERSION}
+        done
 
         git config --global user.email ${GITHUB_ACTOR}@voiapp.io
         git config --global user.name ${GITHUB_ACTOR}


### PR DESCRIPTION
When merging a PR we need to change many values files in once single commit to avoid concurrent creation of commits to main in argo-cd-apps. We solve this by allow the caller to provide a comma separated list of environments to deploy to.